### PR TITLE
Jared

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,33 +43,33 @@ version.h:
 
 ##bcftools code
 filter.o: filter.c filter.h
-	$(CC)  $(IFLAGS) -c $<  
+	$(CC)  $(CFLAGS) $(IFLAGS) -c $<  
 version.o: version.c filter.h version.h
-	$(CC)  $(IFLAGS) -c $<  
+	$(CC)  $(CFLAGS) $(IFLAGS) -c $<  
 ##akt code
 relatives.o: relatives.cpp 
-	$(CXX) -c relatives.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c relatives.cpp $(IFLAGS)
 vcfpca.o: vcfpca.cpp 
-	$(CXX) -c vcfpca.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS) -c vcfpca.cpp $(IFLAGS)
 cluster.o: cluster.cpp 
-	$(CXX) -c cluster.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c cluster.cpp $(IFLAGS)
 kin.o: kin.cpp 
-	$(CXX) -c kin.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c kin.cpp $(IFLAGS)
 ibd.o: ibd.cpp 
-	$(CXX) -c ibd.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c ibd.cpp $(IFLAGS)
 pedigree.o: pedigree.cpp pedigree.h
-	$(CXX) -c $< $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c $< $(IFLAGS)
 mendel.o: pedigree.h mendel.cpp 
-	$(CXX) -c mendel.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c mendel.cpp $(IFLAGS)
 stats.o: stats.cpp 
-	$(CXX) -c stats.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c stats.cpp $(IFLAGS)
 reader.o: reader.cpp 
-	$(CXX) -c reader.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c reader.cpp $(IFLAGS)
 ldplot.o: ldplot.cpp 
-	$(CXX) -c ldplot.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS)  -c ldplot.cpp $(IFLAGS)
 admix.o: admix.cpp 
-	$(CXX)	 -c admix.cpp $(IFLAGS)
+	$(CXX) $(CXXFLAGS) -c admix.cpp $(IFLAGS)
 akt: version.h akt.cpp admix.o ldplot.o reader.o vcfpca.o relatives.o kin.o ibd.o cluster.o stats.o pedigree.o mendel.o filter.o version.o $(HTSLIB)
-	$(CXX)  -o akt akt.cpp admix.o ldplot.o reader.o vcfpca.o relatives.o kin.o ibd.o cluster.o stats.o pedigree.o mendel.o filter.o version.o $(IFLAGS) $(HTSLIB) $(LFLAGS) $(CXXFLAGS)
+	$(CXX) $(CXXFLAGS)   -o akt akt.cpp admix.o ldplot.o reader.o vcfpca.o relatives.o kin.o ibd.o cluster.o stats.o pedigree.o mendel.o filter.o version.o $(IFLAGS) $(HTSLIB) $(LFLAGS) $(CXXFLAGS)
 clean:
 	rm *.o akt version.h

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 CC=gcc
 CXX=g++
-CXXFLAGS = -O3 -DNDEBUG -fopenmp
-CFLAGS = -O3 -DNDEBUG -fopenmp
+
+OMP=-fopenmp
+
+CXXFLAGS = -O3 -DNDEBUG $(OMP)
+CFLAGS = -O3 -DNDEBUG $(OMP)
 
 all: akt
 
@@ -12,16 +15,16 @@ IFLAGS = -I$(HTSDIR)  -I./
 LFLAGS = -lz -lm
 
 
-default: CXXFLAGS = -O3 -DNDEBUG -fopenmp
-default: CFLAGS = -O3 -DNDEBUG -fopenmp
+default: CXXFLAGS = -O3 -DNDEBUG $(OMP)
+default: CFLAGS = -O3 -DNDEBUG $(OMP)
 default: all
 
-debug: CXXFLAGS = -g -O1 -fopenmp
-debug: CFLAGS =  -g -O1 -fopenmp
+debug: CXXFLAGS = -g -O1 $(OMP)
+debug: CFLAGS =  -g -O1 $(OMP)
 debug: all
 
-profile: CXXFLAGS = -pg -O3 -fopenmp
-profile: CFLAGS =  -pg -O3 -fopenmp
+profile: CXXFLAGS = -pg -O3 $(OMP)
+profile: CFLAGS =  -pg -O3 $(OMP)
 profile: all
 
 ##generates a version
@@ -37,35 +40,33 @@ version.h:
 
 ##bcftools code
 filter.o: filter.c filter.h
-	$(CC) $(CFLAGS) $(IFLAGS) -c $<  
+	$(CC)  $(IFLAGS) -c $<  
 version.o: version.c filter.h version.h
-	$(CC) $(CFLAGS) $(IFLAGS) -c $<  
+	$(CC)  $(IFLAGS) -c $<  
 ##akt code
 relatives.o: relatives.cpp 
-	$(CXX)  $(CXXFLAGS) -c relatives.cpp $(IFLAGS)
+	$(CXX) -c relatives.cpp $(IFLAGS)
 vcfpca.o: vcfpca.cpp 
-	$(CXX)  $(CXXFLAGS) -c vcfpca.cpp $(IFLAGS)
+	$(CXX) -c vcfpca.cpp $(IFLAGS)
 cluster.o: cluster.cpp 
-	$(CXX)  $(CXXFLAGS) -c cluster.cpp $(IFLAGS)
+	$(CXX) -c cluster.cpp $(IFLAGS)
 kin.o: kin.cpp 
-	$(CXX)  $(CXXFLAGS) -c kin.cpp $(IFLAGS)
+	$(CXX) -c kin.cpp $(IFLAGS)
 ibd.o: ibd.cpp 
-	$(CXX)  $(CXXFLAGS) -c ibd.cpp $(IFLAGS)
+	$(CXX) -c ibd.cpp $(IFLAGS)
 pedigree.o: pedigree.cpp pedigree.h
-	$(CXX)  $(CXXFLAGS) -c $< $(IFLAGS)
+	$(CXX) -c $< $(IFLAGS)
 mendel.o: pedigree.h mendel.cpp 
-	$(CXX)  $(CXXFLAGS) -c mendel.cpp $(IFLAGS)
+	$(CXX) -c mendel.cpp $(IFLAGS)
 stats.o: stats.cpp 
-	$(CXX)  $(CXXFLAGS) -c stats.cpp $(IFLAGS)
+	$(CXX) -c stats.cpp $(IFLAGS)
 reader.o: reader.cpp 
-	$(CXX)  $(CXXFLAGS) -c reader.cpp $(IFLAGS)
+	$(CXX) -c reader.cpp $(IFLAGS)
 ldplot.o: ldplot.cpp 
-	$(CXX)  $(CXXFLAGS) -c ldplot.cpp $(IFLAGS)
+	$(CXX) -c ldplot.cpp $(IFLAGS)
 admix.o: admix.cpp 
-	$(CXX)  $(CXXFLAGS) -c admix.cpp $(IFLAGS)
+	$(CXX)	 -c admix.cpp $(IFLAGS)
 akt: version.h akt.cpp admix.o ldplot.o reader.o vcfpca.o relatives.o kin.o ibd.o cluster.o stats.o pedigree.o mendel.o filter.o version.o $(HTSLIB)
 	$(CXX)  -o akt akt.cpp admix.o ldplot.o reader.o vcfpca.o relatives.o kin.o ibd.o cluster.o stats.o pedigree.o mendel.o filter.o version.o $(IFLAGS) $(HTSLIB) $(LFLAGS) $(CXXFLAGS)
-
 clean:
 	rm *.o akt version.h
-

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ HTSLIB = $(HTSDIR)/libhts.a
 IFLAGS = -I$(HTSDIR)  -I./
 LFLAGS = -lz -lm
 
+no_omp: CXXFLAGS = -O3 -DNDEBUG 
+no_omp: CFLAGS = -O3 -DNDEBUG 
+no_omp: all
 
 default: CXXFLAGS = -O3 -DNDEBUG $(OMP)
 default: CFLAGS = -O3 -DNDEBUG $(OMP)

--- a/akt.hpp
+++ b/akt.hpp
@@ -17,13 +17,20 @@
 #include <limits>
 #include <stdlib.h> 
 #include <iterator>
-#include <omp.h>
 #include <map>
 #include <list>
 #include <algorithm>
 #include <set>
 #include <stdexcept>     
 #include "samples.hpp"
+
+#ifdef _OPENMP
+   #include <omp.h>
+#else
+   #define omp_get_thread_num() 0
+   #define omp_get_num_threads() 0
+static void inline omp_set_num_threads(int nthreads) {} 
+#endif
 
 extern "C" {
 #include "htslib/synced_bcf_reader.h"

--- a/akt.hpp
+++ b/akt.hpp
@@ -27,8 +27,14 @@
 #ifdef _OPENMP
    #include <omp.h>
 #else
-   #define omp_get_thread_num() 0
-   #define omp_get_num_threads() 0
+static int inline omp_get_thread_num() {
+  std::cerr<<"WARNING: threading is disabled"<<endl;
+  return(0);
+}
+static int inline omp_get_num_threads() {
+  std::cerr<<"WARNING: threading is disabled"<<endl;
+  return(0);
+}
 static void inline omp_set_num_threads(int nthreads) {} 
 #endif
 

--- a/ldplot.cpp
+++ b/ldplot.cpp
@@ -127,6 +127,6 @@ int ldplot_main(int argc, char* argv[])
 	while(!gt.empty()) free(gt.back()), gt.pop_back(); 
 
 	cout << Sigma << endl;
-	
+	return(0);
 }
 

--- a/pedigree.cpp
+++ b/pedigree.cpp
@@ -50,6 +50,7 @@ int sampleInfo::readFromPlinkFam(string fname) {
     inf.ignore(10000,'\n');
   }
   cerr << "Read "<<N<<" individuals from "<<fname<<endl;
+  return(0);
 }
 
 int sampleInfo::buildIndex() {

--- a/stats.cpp
+++ b/stats.cpp
@@ -411,5 +411,6 @@ int stats_main(int argc, char* argv[])
 	bcf_hdr_destroy(hdr);
 	bcf_hdr_destroy(new_hdr);
 	bcf_destroy1(rec);
+	return(0);
 }
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,7 +3,7 @@
 ##build akt
 cd ../
 make clean
-make
+make -j 4
 cd test/
 
 ##get data
@@ -26,7 +26,7 @@ time ../akt pca -w ../data/1000G.snps.nochr.vcf.gz $data  > pca2.txt
 Rscript ../scripts/1000G_pca.R pca2.txt 
 
 ##calculate kinship coefficients
-time ../akt kin -R ../data/1000G.snps.nochr.vcf.gz $data > kinship.txt
+time ../akt kin -n 4 -R ../data/1000G.snps.nochr.vcf.gz $data > kinship.txt
 
 ##find relatives
 time ../akt relatives -p n433 kinship.txt > relatives.out


### PR DESCRIPTION
#1 added `make no_omp` option for compilers without omp support
