### PR TITLE
makefile fix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 ## Changelog
+## 2018.07.13
+* fixed a typo in akt relatives output
+* fixed a makefile bug, default was not building with optimisations 
 
 ## 2018.01.30
 * better handling of hemizygous genotypes in the pca routine

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ CXX=g++
 
 OMP=-fopenmp
 
-CXXFLAGS =  -std=c++11
+CXXFLAGS = -std=c++11 -O2  $(OMP) -mpopcnt
+CFLAGS = -O2  $(OMP) -mpopcnt
 
 .PHONY: all
 all: akt
@@ -14,24 +15,19 @@ HTSLIB = $(HTSDIR)/libhts.a
 IFLAGS = -I$(HTSDIR)  -I./
 LFLAGS = -lz -lm  -lpthread
 
-.PHONY: default
-default: CXXFLAGS += -O2  $(OMP) -mpopcnt
-default: CFLAGS = -O2  $(OMP) -mpopcnt
-default: all
-
 .PHONY: no_omp
-no_omp: CXXFLAGS += -O2 
+no_omp: CXXFLAGS = -std=c++11 -O2 
 no_omp: CFLAGS = -O2 
 no_omp: all
 
 .PHONY: release
-release: CXXFLAGS += -O2  $(OMP) -mpopcnt
+release: CXXFLAGS = -std=c++11 -O2  $(OMP) -mpopcnt
 release: CFLAGS = -O2  $(OMP) -mpopcnt
 release: LFLAGS +=  -static
 release: all
 
 .PHONY: debug
-debug: CXXFLAGS += -g -O1 -Wall
+debug: CXXFLAGS = -std=c++11 -g -O1 -Wall
 debug: CFLAGS = -g -O1  -lz -lm -lpthread
 debug: all
 

--- a/relatives.cpp
+++ b/relatives.cpp
@@ -17,7 +17,7 @@ using namespace Eigen;
  *
  */
 static void usage() {
-    cerr << "Print a list of unrelated individuals taking the output from akt kin as input." << endl;
+    cerr << "Derive a set of pedigrees from the akt kin output." << endl;
     cerr << "Usage:" << endl;
     cerr << "./akt unrelated ibdfile" << endl;
     cerr << "\t -k --kmin:			threshold for relatedness (0.05)" << endl;


### PR DESCRIPTION
@olest This fixes an issue with the makefile where the default build was not turning on `-O2` causing poor performance.