### PR TITLE
Allow both -R/-r and -F

### DIFF
--- a/kin.cpp
+++ b/kin.cpp
@@ -321,7 +321,7 @@ int kin_main(int argc, char* argv[])
     assert(min_freq>=0 && min_freq<=1);
     if((!targets.empty() && !regions.empty()) )  
     {
-	cerr<<"ERROR: -r/-R and -r/-R are incompatible"<<endl;
+	cerr<<"ERROR: -t/-T and -r/-R are incompatible"<<endl;
 	exit(1);
     }
     if(!frq_file.empty() && !regions.empty()) 

--- a/kin.cpp
+++ b/kin.cpp
@@ -324,16 +324,6 @@ int kin_main(int argc, char* argv[])
 	cerr<<"ERROR: -t/-T and -r/-R are incompatible"<<endl;
 	exit(1);
     }
-    if(!frq_file.empty() && !regions.empty()) 
-    {
-	cerr<<"ERROR: -F and -R/-r are incompatible!"<<endl;
-	exit(1);
-    } 
-    if(!frq_file.empty() && regions.empty())
-    {
-	regions=frq_file;
-	regions_is_file=true;
-    }
     if(frq_file.empty())  
     {
 	cerr<<"No frequency VCF provided (-F). Allele frequencies will be estimated from the data."<<endl;


### PR DESCRIPTION
This addresses #31 by removing the code preventing -r/-R and -F from both being used in kin, and also removes the default of using the `frq_file` as the `regions` for bcf synced reader.

The prior behavior would still be available by specifying the same file as both `-R` and `-F`.

Bonus commit: fixes a typo in an error message. 